### PR TITLE
Refactor color schemes

### DIFF
--- a/charge/src/main/java/de/elvah/charge/features/adhoc_charging/ui/screens/activecharging/ActiveChargingScreen.kt
+++ b/charge/src/main/java/de/elvah/charge/features/adhoc_charging/ui/screens/activecharging/ActiveChargingScreen.kt
@@ -46,7 +46,7 @@ import de.elvah.charge.platform.ui.components.FullScreenError
 import de.elvah.charge.platform.ui.components.FullScreenLoading
 import de.elvah.charge.platform.ui.components.TitleSmall
 import de.elvah.charge.platform.ui.components.TopAppBar
-import de.elvah.charge.platform.ui.theme.brand
+import de.elvah.charge.platform.ui.theme.colors.ElvahChargeThemeExtension.colorSchemeExtended
 import de.elvah.charge.platform.ui.theme.copyMedium
 import de.elvah.charge.platform.ui.theme.titleMediumBold
 import de.elvah.charge.platform.ui.theme.titleXLargeBold
@@ -280,7 +280,7 @@ internal fun ActiveCharging_Stopping(
 @Composable
 private fun CircularProgressWithTick(modifier: Modifier = Modifier) {
     Box(modifier = modifier, contentAlignment = Alignment.Center) {
-        CircularProgressIndicator(Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.brand)
+        CircularProgressIndicator(Modifier.fillMaxSize(), color = MaterialTheme.colorSchemeExtended.brand)
         TickIcon(Modifier.fillMaxSize())
     }
 }
@@ -382,7 +382,7 @@ private fun WaitingChargingActions(
         LinearProgressIndicator(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(10.dp), color = MaterialTheme.colorScheme.brand
+                .height(10.dp), color = MaterialTheme.colorSchemeExtended.brand
         )
 
         ButtonTertiary(stringResource(R.string.support_button), onClick = onSupportClick)
@@ -402,7 +402,7 @@ private fun StopChargingActions(
         LinearProgressIndicator(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(10.dp), color = MaterialTheme.colorScheme.brand
+                .height(10.dp), color = MaterialTheme.colorSchemeExtended.brand
         )
         ButtonTertiary(stringResource(R.string.support_button), onClick = onSupportClick)
     }

--- a/charge/src/main/java/de/elvah/charge/features/adhoc_charging/ui/screens/chargingstart/ChargingStartScreen.kt
+++ b/charge/src/main/java/de/elvah/charge/features/adhoc_charging/ui/screens/chargingstart/ChargingStartScreen.kt
@@ -49,7 +49,7 @@ import de.elvah.charge.platform.ui.components.TickBanner
 import de.elvah.charge.platform.ui.components.TitleMedium
 import de.elvah.charge.platform.ui.components.TitleSmall
 import de.elvah.charge.platform.ui.theme.ElvahChargeTheme
-import de.elvah.charge.platform.ui.theme.brand
+import de.elvah.charge.platform.ui.theme.colors.ElvahChargeThemeExtension.colorSchemeExtended
 import de.elvah.charge.platform.ui.theme.onBrand
 import kotlinx.coroutines.launch
 
@@ -298,7 +298,7 @@ private fun ConnectVehicleMessage(modifier: Modifier = Modifier) {
 private fun ChargingIdBadge(id: String, modifier: Modifier = Modifier) {
     BasicCard(
         modifier = modifier,
-        backgroundColor = MaterialTheme.colorScheme.brand,
+        backgroundColor = MaterialTheme.colorSchemeExtended.brand,
         paddingValues = PaddingValues(10.dp)
     ) {
         Row(

--- a/charge/src/main/java/de/elvah/charge/features/adhoc_charging/ui/screens/chargingstart/ChargingStartScreen.kt
+++ b/charge/src/main/java/de/elvah/charge/features/adhoc_charging/ui/screens/chargingstart/ChargingStartScreen.kt
@@ -50,9 +50,7 @@ import de.elvah.charge.platform.ui.components.TitleMedium
 import de.elvah.charge.platform.ui.components.TitleSmall
 import de.elvah.charge.platform.ui.theme.ElvahChargeTheme
 import de.elvah.charge.platform.ui.theme.colors.ElvahChargeThemeExtension.colorSchemeExtended
-import de.elvah.charge.platform.ui.theme.onBrand
 import kotlinx.coroutines.launch
-
 
 @Composable
 internal fun ChargingStartScreen(
@@ -307,14 +305,14 @@ private fun ChargingIdBadge(id: String, modifier: Modifier = Modifier) {
         ) {
             Icon(
                 painter = painterResource(R.drawable.ic_plug),
-                tint = MaterialTheme.colorScheme.onBrand,
+                tint = MaterialTheme.colorSchemeExtended.onBrand,
                 contentDescription = null
             )
             Text(
                 id,
                 fontSize = 18.sp,
                 fontWeight = FontWeight.W600,
-                color = MaterialTheme.colorScheme.onBrand
+                color = MaterialTheme.colorSchemeExtended.onBrand,
             )
         }
     }

--- a/charge/src/main/java/de/elvah/charge/features/adhoc_charging/ui/screens/sitedetail/SiteDetailScreen.kt
+++ b/charge/src/main/java/de/elvah/charge/features/adhoc_charging/ui/screens/sitedetail/SiteDetailScreen.kt
@@ -46,7 +46,7 @@ import de.elvah.charge.platform.ui.components.CopyXLarge
 import de.elvah.charge.platform.ui.components.FullScreenError
 import de.elvah.charge.platform.ui.components.FullScreenLoading
 import de.elvah.charge.platform.ui.theme.ElvahChargeTheme
-import de.elvah.charge.platform.ui.theme.brand
+import de.elvah.charge.platform.ui.theme.colors.ElvahChargeThemeExtension.colorSchemeExtended
 import de.elvah.charge.platform.ui.theme.copyMediumBold
 import de.elvah.charge.platform.ui.theme.copySmallBold
 import de.elvah.charge.platform.ui.theme.titleSmallBold
@@ -141,7 +141,7 @@ private fun OfferBannerAndClose(
                 modifier = Modifier
                     .fillMaxWidth()
                     .background(
-                        color = MaterialTheme.colorScheme.brand.copy(
+                        color = MaterialTheme.colorSchemeExtended.brand.copy(
                             alpha = 0.1f,
                         ),
                     )
@@ -157,7 +157,7 @@ private fun OfferBannerAndClose(
                         ),
                     text = "Offer ends in 13h 11m",
                     style = copySmallBold,
-                    color = MaterialTheme.colorScheme.brand,
+                    color = MaterialTheme.colorSchemeExtended.brand,
                     textAlign = TextAlign.Center
                 )
             }

--- a/charge/src/main/java/de/elvah/charge/features/adhoc_charging/ui/screens/sitedetail/chargepointslist/ChargePointItem.kt
+++ b/charge/src/main/java/de/elvah/charge/features/adhoc_charging/ui/screens/sitedetail/chargepointslist/ChargePointItem.kt
@@ -30,7 +30,6 @@ import de.elvah.charge.features.sites.ui.model.ChargePointUI
 import de.elvah.charge.platform.ui.components.CopyMedium
 import de.elvah.charge.platform.ui.components.CopySmall
 import de.elvah.charge.platform.ui.theme.ElvahChargeTheme
-import de.elvah.charge.platform.ui.theme.brand
 import de.elvah.charge.platform.ui.theme.colors.ElvahChargeThemeExtension.colorSchemeExtended
 import de.elvah.charge.platform.ui.theme.copyLargeBold
 import de.elvah.charge.platform.ui.theme.copyXLargeBold
@@ -120,7 +119,7 @@ private fun getAvailabilityColor(
     return when (availability) {
         ChargePointAvailability.AVAILABLE,
             -> {
-            MaterialTheme.colorScheme.brand
+            MaterialTheme.colorSchemeExtended.brand
         }
 
         ChargePointAvailability.OUT_OF_SERVICE,
@@ -140,7 +139,7 @@ private fun BadgeStatus(
     val backgroundColor = when (availability) {
         ChargePointAvailability.AVAILABLE,
             -> {
-            MaterialTheme.colorScheme.brand
+            MaterialTheme.colorSchemeExtended.brand
         }
 
         ChargePointAvailability.OUT_OF_SERVICE,

--- a/charge/src/main/java/de/elvah/charge/features/adhoc_charging/ui/screens/sitedetail/chargepointslist/ChargePointItem.kt
+++ b/charge/src/main/java/de/elvah/charge/features/adhoc_charging/ui/screens/sitedetail/chargepointslist/ChargePointItem.kt
@@ -31,9 +31,9 @@ import de.elvah.charge.platform.ui.components.CopyMedium
 import de.elvah.charge.platform.ui.components.CopySmall
 import de.elvah.charge.platform.ui.theme.ElvahChargeTheme
 import de.elvah.charge.platform.ui.theme.brand
+import de.elvah.charge.platform.ui.theme.colors.ElvahChargeThemeExtension.colorSchemeExtended
 import de.elvah.charge.platform.ui.theme.copyLargeBold
 import de.elvah.charge.platform.ui.theme.copyXLargeBold
-import de.elvah.charge.platform.ui.theme.decorativeStroke
 
 @Composable
 internal fun ChargePointItem(
@@ -147,7 +147,7 @@ private fun BadgeStatus(
         ChargePointAvailability.UNAVAILABLE,
         ChargePointAvailability.UNKNOWN,
             -> {
-            decorativeStroke
+            MaterialTheme.colorSchemeExtended.decorativeStroke
         }
     }
 

--- a/charge/src/main/java/de/elvah/charge/features/sites/ui/components/ChargeBanner.kt
+++ b/charge/src/main/java/de/elvah/charge/features/sites/ui/components/ChargeBanner.kt
@@ -35,7 +35,7 @@ import de.elvah.charge.platform.ui.components.Chevron
 import de.elvah.charge.platform.ui.components.CopyMedium
 import de.elvah.charge.platform.ui.components.CopySmall
 import de.elvah.charge.platform.ui.theme.ElvahChargeTheme
-import de.elvah.charge.platform.ui.theme.brand
+import de.elvah.charge.platform.ui.theme.colors.ElvahChargeThemeExtension.colorSchemeExtended
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlin.time.Duration
@@ -199,7 +199,7 @@ private fun
         LiveCounter(chargeTime) {
             CopySmall(
                 text = it.toString(),
-                color = MaterialTheme.colorScheme.brand,
+                color = MaterialTheme.colorSchemeExtended.brand,
                 fontWeight = FontWeight.W700
             )
         }
@@ -229,7 +229,7 @@ private fun BestDealTimeLeft(timeLeft: String, modifier: Modifier = Modifier) {
     CopySmall(
         text = parseDate(timeLeft),
         modifier = modifier,
-        color = MaterialTheme.colorScheme.brand,
+        color = MaterialTheme.colorSchemeExtended.brand,
         fontWeight = FontWeight.W700
     )
 }

--- a/charge/src/main/java/de/elvah/charge/platform/ui/components/Badges.kt
+++ b/charge/src/main/java/de/elvah/charge/platform/ui/components/Badges.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import de.elvah.charge.R
-import de.elvah.charge.platform.ui.theme.brand
+import de.elvah.charge.platform.ui.theme.colors.ElvahChargeThemeExtension.colorSchemeExtended
 
 @Composable
 internal fun BrandBadge(
@@ -51,7 +51,7 @@ private fun BrandBadge_Preview() {
 internal fun ChargingBadge(
     progress: Int,
     modifier: Modifier = Modifier,
-    tint: Color = MaterialTheme.colorScheme.brand,
+    tint: Color = MaterialTheme.colorSchemeExtended.brand,
 ) {
     Row(
         modifier = modifier,

--- a/charge/src/main/java/de/elvah/charge/platform/ui/components/Banners.kt
+++ b/charge/src/main/java/de/elvah/charge/platform/ui/components/Banners.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -23,9 +24,7 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import de.elvah.charge.R
 import de.elvah.charge.platform.ui.theme.ElvahChargeTheme
-import de.elvah.charge.platform.ui.theme.onSuccess
-import de.elvah.charge.platform.ui.theme.primary
-import de.elvah.charge.platform.ui.theme.success
+import de.elvah.charge.platform.ui.theme.colors.ElvahChargeThemeExtension.colorSchemeExtended
 import kotlinx.coroutines.delay
 
 
@@ -61,7 +60,7 @@ internal fun Banner(
 ) {
     Card(
         modifier = modifier,
-        colors = CardDefaults.cardColors(containerColor = success)
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorSchemeExtended.success)
     ) {
         Row(
             modifier = Modifier
@@ -72,12 +71,16 @@ internal fun Banner(
             Icon(
                 painter = painterResource(icon),
                 contentDescription = contentDescription,
-                tint = onSuccess
+                tint = MaterialTheme.colorSchemeExtended.onSuccess,
             )
 
             Spacer(modifier = Modifier.size(12.dp))
 
-            Text(text, color = primary, fontWeight = FontWeight.W600)
+            Text(
+                text,
+                color = MaterialTheme.colorSchemeExtended.primary,
+                fontWeight = FontWeight.W600
+            )
 
             onCloseClick?.let {
                 Spacer(modifier = Modifier.weight(1f))

--- a/charge/src/main/java/de/elvah/charge/platform/ui/components/Buttons.kt
+++ b/charge/src/main/java/de/elvah/charge/platform/ui/components/Buttons.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import de.elvah.charge.R
 import de.elvah.charge.platform.ui.theme.ElvahChargeTheme
-import de.elvah.charge.platform.ui.theme.brand
+import de.elvah.charge.platform.ui.theme.colors.ElvahChargeThemeExtension.colorSchemeExtended
 import de.elvah.charge.platform.ui.theme.copyLargeBold
 import de.elvah.charge.platform.ui.theme.onBrand
 
@@ -64,7 +64,7 @@ internal fun ButtonPrimary(
         modifier = modifier,
         shape = RoundedCornerShape(12.dp),
         colors = ButtonDefaults.buttonColors(
-            containerColor = MaterialTheme.colorScheme.brand,
+            containerColor = MaterialTheme.colorSchemeExtended.brand,
             contentColor = MaterialTheme.colorScheme.onBrand
         )
     ) {
@@ -96,7 +96,7 @@ internal fun SecondaryButton(
     text: String,
     modifier: Modifier = Modifier,
     @DrawableRes icon: Int? = null,
-    tint: Color = MaterialTheme.colorScheme.brand,
+    tint: Color = MaterialTheme.colorSchemeExtended.brand,
     onClick: () -> Unit,
 ) {
 

--- a/charge/src/main/java/de/elvah/charge/platform/ui/components/Buttons.kt
+++ b/charge/src/main/java/de/elvah/charge/platform/ui/components/Buttons.kt
@@ -27,7 +27,6 @@ import de.elvah.charge.R
 import de.elvah.charge.platform.ui.theme.ElvahChargeTheme
 import de.elvah.charge.platform.ui.theme.colors.ElvahChargeThemeExtension.colorSchemeExtended
 import de.elvah.charge.platform.ui.theme.copyLargeBold
-import de.elvah.charge.platform.ui.theme.onBrand
 
 @Composable
 internal fun GooglePayButton(
@@ -65,7 +64,7 @@ internal fun ButtonPrimary(
         shape = RoundedCornerShape(12.dp),
         colors = ButtonDefaults.buttonColors(
             containerColor = MaterialTheme.colorSchemeExtended.brand,
-            contentColor = MaterialTheme.colorScheme.onBrand
+            contentColor = MaterialTheme.colorSchemeExtended.onBrand,
         )
     ) {
         icon?.let {
@@ -76,7 +75,7 @@ internal fun ButtonPrimary(
             text = text,
             modifier = Modifier.padding(vertical = 8.dp),
             style = copyLargeBold,
-            color = MaterialTheme.colorScheme.onBrand
+            color = MaterialTheme.colorSchemeExtended.onBrand,
         )
     }
 }

--- a/charge/src/main/java/de/elvah/charge/platform/ui/components/Cards.kt
+++ b/charge/src/main/java/de/elvah/charge/platform/ui/components/Cards.kt
@@ -15,13 +15,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import de.elvah.charge.platform.ui.theme.ElvahChargeTheme
-import de.elvah.charge.platform.ui.theme.decorativeStroke
+import de.elvah.charge.platform.ui.theme.colors.ElvahChargeThemeExtension.colorSchemeExtended
 
 @Composable
 internal fun BasicCard(
     modifier: Modifier = Modifier,
     backgroundColor: Color = MaterialTheme.colorScheme.surface,
-    borderColor: Color = decorativeStroke,
+    borderColor: Color = MaterialTheme.colorSchemeExtended.decorativeStroke,
     paddingValues: PaddingValues = PaddingValues(horizontal = 12.dp, vertical = 16.dp),
     content: @Composable ColumnScope.() -> Unit,
 ) {

--- a/charge/src/main/java/de/elvah/charge/platform/ui/components/SwipeButton.kt
+++ b/charge/src/main/java/de/elvah/charge/platform/ui/components/SwipeButton.kt
@@ -42,7 +42,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import de.elvah.charge.platform.ui.theme.brand
+import de.elvah.charge.platform.ui.theme.colors.ElvahChargeThemeExtension.colorSchemeExtended
 import de.elvah.charge.platform.ui.theme.copyLargeBold
 import de.elvah.charge.platform.ui.theme.onBrand
 import kotlinx.coroutines.delay
@@ -57,7 +57,7 @@ internal fun SwipeButton(
     text: String,
     onSwipeText: String? = null,
     modifier: Modifier = Modifier,
-    backgroundColor: Color = MaterialTheme.colorScheme.brand,
+    backgroundColor: Color = MaterialTheme.colorSchemeExtended.brand,
     contentColor: Color = MaterialTheme.colorScheme.onBrand,
     shouldMoveText: Boolean = true,
     onSwiped: () -> Unit,
@@ -220,6 +220,6 @@ private fun SwipeIndicator(
 @Preview
 @Composable
 private fun SwipeIndicator_Preview() {
-    SwipeIndicator(backgroundColor = Color.White, tint = MaterialTheme.colorScheme.brand)
+    SwipeIndicator(backgroundColor = Color.White, tint = MaterialTheme.colorSchemeExtended.brand)
 
 }

--- a/charge/src/main/java/de/elvah/charge/platform/ui/components/SwipeButton.kt
+++ b/charge/src/main/java/de/elvah/charge/platform/ui/components/SwipeButton.kt
@@ -44,7 +44,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import de.elvah.charge.platform.ui.theme.colors.ElvahChargeThemeExtension.colorSchemeExtended
 import de.elvah.charge.platform.ui.theme.copyLargeBold
-import de.elvah.charge.platform.ui.theme.onBrand
 import kotlinx.coroutines.delay
 import kotlin.math.roundToInt
 
@@ -58,7 +57,7 @@ internal fun SwipeButton(
     onSwipeText: String? = null,
     modifier: Modifier = Modifier,
     backgroundColor: Color = MaterialTheme.colorSchemeExtended.brand,
-    contentColor: Color = MaterialTheme.colorScheme.onBrand,
+    contentColor: Color = MaterialTheme.colorSchemeExtended.onBrand,
     shouldMoveText: Boolean = true,
     onSwiped: () -> Unit,
 ) {

--- a/charge/src/main/java/de/elvah/charge/platform/ui/components/graph/EnergyPriceChart.kt
+++ b/charge/src/main/java/de/elvah/charge/platform/ui/components/graph/EnergyPriceChart.kt
@@ -5,27 +5,37 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import de.elvah.charge.platform.ui.theme.ElvahChargeTheme
-import de.elvah.charge.platform.ui.theme.brand
+import de.elvah.charge.platform.ui.theme.colors.ElvahChargeThemeExtension.colorSchemeExtended
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import kotlin.math.sin
@@ -58,7 +68,7 @@ internal fun EnergyPriceChart(
         initialPage = 1, // Start with today (middle page)
         pageCount = { dailyData.size }
     )
-    
+
     val allHourlyData = dailyData.flatMap { it.hourlyData }
     val maxPrice = allHourlyData.maxOf { it.price }
     val calculatedMinPrice = allHourlyData.minOf { it.price }
@@ -119,7 +129,7 @@ private fun DayChart(
             color = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.padding(bottom = 16.dp)
         )
-        
+
         // Hourly chart
         Box(
             modifier = Modifier
@@ -135,7 +145,7 @@ private fun DayChart(
                     gridLineDotSize = gridLineDotSize
                 )
             }
-            
+
             // Bars
             Row(
                 modifier = Modifier
@@ -165,7 +175,7 @@ private fun EnergyPriceBar(
     minPrice: Double,
     progress: Float,
     showHourLabel: Boolean = true,
-    barColor: Color = MaterialTheme.colorScheme.brand,
+    barColor: Color = MaterialTheme.colorSchemeExtended.brand,
     modifier: Modifier = Modifier
 ) {
     val barHeight = 120.dp
@@ -217,13 +227,13 @@ private fun DrawScope.drawGridLines(
     gridLineDotSize: Float = 4f
 ) {
     if (!showVerticalGridLines) return
-    
+
     val gridColor = Color.Gray.copy(alpha = 0.3f)
     val stepWidth = size.width / hourCount
-    
+
     // Create dotted path effect
     val pathEffect = PathEffect.dashPathEffect(floatArrayOf(gridLineDotSize, gridLineDotSize), 0f)
-    
+
     // Draw vertical dotted grid lines every gridLineInterval hours
     for (hour in 0 until hourCount step gridLineInterval) {
         val x = hour * stepWidth

--- a/charge/src/main/java/de/elvah/charge/platform/ui/components/graph/EnergyPriceChartBase.kt
+++ b/charge/src/main/java/de/elvah/charge/platform/ui/components/graph/EnergyPriceChartBase.kt
@@ -5,14 +5,25 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -28,7 +39,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import de.elvah.charge.platform.ui.theme.ElvahChargeTheme
-import de.elvah.charge.platform.ui.theme.brand
+import de.elvah.charge.platform.ui.theme.colors.ElvahChargeThemeExtension.colorSchemeExtended
 import java.time.LocalDate
 
 private data class EnergyPriceData1(
@@ -44,18 +55,18 @@ private fun EnergyPriceChart1(
     animated: Boolean = true
 ) {
     if (data.isEmpty()) return
-    
+
     val scrollState = rememberScrollState()
     val maxPrice = data.maxOf { it.price }
     val minPrice = data.minOf { it.price }
     val priceRange = maxPrice - minPrice
-    
+
     val animatedProgress by animateFloatAsState(
         targetValue = if (animated) 1f else 1f,
         animationSpec = tween(durationMillis = 1000),
         label = "chart_animation"
     )
-    
+
     Card(
         modifier = modifier,
         colors = CardDefaults.cardColors(
@@ -90,7 +101,7 @@ private fun EnergyPriceChart1(
                     )
                 }
             }
-            
+
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -123,21 +134,21 @@ private fun EnergyPriceBar(
     val density = LocalDensity.current
     val barHeight = 120.dp
     val barWidth = 32.dp
-    
+
     val normalizedHeight = if (maxPrice > minPrice) {
         ((data.price - minPrice) / (maxPrice - minPrice)).toFloat()
     } else {
         1f
     }
-    
+
     val currentHeight = (normalizedHeight * progress).coerceIn(0f, 1f)
-    
+
     val barColor = when {
         data.price < (minPrice + (maxPrice - minPrice) * 0.33) -> Color(0xFF4CAF50) // Green for low prices
         data.price < (minPrice + (maxPrice - minPrice) * 0.66) -> Color(0xFFFF9800) // Orange for medium prices
         else -> Color(0xFFF44336) // Red for high prices
     }
-    
+
     Column(
         modifier = modifier.width(barWidth),
         horizontalAlignment = Alignment.CenterHorizontally
@@ -149,7 +160,7 @@ private fun EnergyPriceBar(
             textAlign = TextAlign.Center,
             modifier = Modifier.padding(bottom = 4.dp)
         )
-        
+
         Box(
             modifier = Modifier
                 .width(barWidth)
@@ -164,7 +175,7 @@ private fun EnergyPriceBar(
                     .align(Alignment.BottomCenter)
             )
         }
-        
+
         Text(
             text = "${data.hour}:00",
             style = MaterialTheme.typography.bodySmall.copy(fontSize = 10.sp),
@@ -182,19 +193,19 @@ internal fun EnergyPriceLineChart1(
     animated: Boolean = true
 ) {
     if (data.isEmpty()) return
-    
+
     val scrollState = rememberScrollState()
     val maxPrice = data.maxOf { it.price }
     val minPrice = data.minOf { it.price }
-    
+
     val animatedProgress by animateFloatAsState(
         targetValue = if (animated) 1f else 1f,
         animationSpec = tween(durationMillis = 1200),
         label = "line_chart_animation"
     )
-    
-    val brandColor = MaterialTheme.colorScheme.brand
-    
+
+    val brandColor = MaterialTheme.colorSchemeExtended.brand
+
     Card(
         modifier = modifier,
         colors = CardDefaults.cardColors(
@@ -213,7 +224,7 @@ internal fun EnergyPriceLineChart1(
                 color = MaterialTheme.colorScheme.onSurface,
                 modifier = Modifier.padding(bottom = 16.dp)
             )
-            
+
             Box(
                 modifier = Modifier
                     .height(160.dp)
@@ -234,7 +245,7 @@ internal fun EnergyPriceLineChart1(
                     )
                 }
             }
-            
+
             Row(
                 modifier = Modifier
                     .horizontalScroll(scrollState)
@@ -264,16 +275,16 @@ private fun DrawScope.drawEnergyPriceLine(
     brandColor: Color
 ) {
     if (data.size < 2) return
-    
+
     val stepX = size.width / (data.size - 1)
     val priceRange = maxPrice - minPrice
-    
+
     val path = Path()
     val gradientPath = Path()
-    
+
     val visibleDataCount = (data.size * progress).toInt().coerceAtLeast(1)
     val visibleData = data.take(visibleDataCount)
-    
+
     visibleData.forEachIndexed { index, priceData ->
         val x = index * stepX
         val normalizedPrice = if (priceRange > 0) {
@@ -282,7 +293,7 @@ private fun DrawScope.drawEnergyPriceLine(
             0.5f
         }
         val y = size.height - (normalizedPrice * size.height * 0.8f) - size.height * 0.1f
-        
+
         if (index == 0) {
             path.moveTo(x, y)
             gradientPath.moveTo(x, size.height)
@@ -291,22 +302,22 @@ private fun DrawScope.drawEnergyPriceLine(
             path.lineTo(x, y)
             gradientPath.lineTo(x, y)
         }
-        
+
         drawCircle(
             color = brandColor,
             radius = 4.dp.toPx(),
             center = Offset(x, y)
         )
     }
-    
+
     gradientPath.lineTo(visibleData.lastIndex * stepX, size.height)
     gradientPath.close()
-    
+
     drawPath(
         path = gradientPath,
         color = brandColor.copy(alpha = 0.2f)
     )
-    
+
     drawPath(
         path = path,
         color = brandColor,
@@ -364,7 +375,7 @@ private fun EnergyPriceChartDarkPreview() {
                 dailyData = generateThreeDaySampleData(),
                 modifier = Modifier.fillMaxWidth()
             )
-            
+
             EnergyPriceLineChart1(
                 data = generateSampleEnergyData(),
                 modifier = Modifier.fillMaxWidth()
@@ -379,7 +390,9 @@ private fun EnergyPriceChartHighVariationPreview() {
     ElvahChargeTheme {
         EnergyPriceChart(
             dailyData = generateThreeDayHighVariationData(),
-            modifier = Modifier.fillMaxWidth().padding(16.dp)
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
         )
     }
 }
@@ -390,7 +403,9 @@ private fun EnergyPriceChartLowVariationPreview() {
     ElvahChargeTheme {
         EnergyPriceChart(
             dailyData = generateThreeDayLowVariationData(),
-            modifier = Modifier.fillMaxWidth().padding(16.dp)
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
         )
     }
 }

--- a/charge/src/main/java/de/elvah/charge/platform/ui/components/graph/line/EnergyPriceLineChart.kt
+++ b/charge/src/main/java/de/elvah/charge/platform/ui/components/graph/line/EnergyPriceLineChart.kt
@@ -29,7 +29,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -61,7 +60,7 @@ import de.elvah.charge.platform.ui.components.graph.line.GraphConstants.DEFAULT_
 import de.elvah.charge.platform.ui.components.graph.line.GraphConstants.DEFAULT_MINUTE_RESOLUTION
 import de.elvah.charge.platform.ui.components.graph.line.utils.getClickedTimeByOffset
 import de.elvah.charge.platform.ui.theme.ElvahChargeTheme
-import de.elvah.charge.platform.ui.theme.brand
+import de.elvah.charge.platform.ui.theme.colors.ElvahChargeThemeExtension.colorSchemeExtended
 import kotlinx.coroutines.launch
 import java.time.LocalDate
 import java.time.LocalTime
@@ -278,7 +277,7 @@ private fun LivePricingPrice(
                 R.string.kwh_label
             ),
             color = if (offerSelected) {
-                MaterialTheme.colorScheme.brand
+                MaterialTheme.colorSchemeExtended.brand
             } else {
                 MaterialTheme.colorScheme.primary
             }
@@ -344,7 +343,7 @@ private fun OfferBadge(priceOffer: PriceOffer?, modifier: Modifier = Modifier) {
                 R.drawable.ic_no_offer
             ), contentDescription = null,
             tint = if (priceOffer != null) {
-                MaterialTheme.colorScheme.brand
+                MaterialTheme.colorSchemeExtended.brand
             } else {
                 MaterialTheme.colorScheme.secondary
             }
@@ -358,7 +357,7 @@ private fun OfferBadge(priceOffer: PriceOffer?, modifier: Modifier = Modifier) {
             },
             fontWeight = FontWeight.W700,
             color = if (priceOffer != null) {
-                MaterialTheme.colorScheme.brand
+                MaterialTheme.colorSchemeExtended.brand
             } else {
                 MaterialTheme.colorScheme.primary
             }
@@ -459,7 +458,9 @@ private fun TypeModalContent(
 @Composable
 private fun TypeModalContentHeader(modifier: Modifier = Modifier, onClick: () -> Unit) {
     Row(
-        modifier = modifier.fillMaxWidth().padding(horizontal = 16.dp),
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {

--- a/charge/src/main/java/de/elvah/charge/platform/ui/components/graph/line/GraphColorDefaults.kt
+++ b/charge/src/main/java/de/elvah/charge/platform/ui/components/graph/line/GraphColorDefaults.kt
@@ -3,7 +3,7 @@ package de.elvah.charge.platform.ui.components.graph.line
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
-import de.elvah.charge.platform.ui.theme.brand
+import de.elvah.charge.platform.ui.theme.colors.ElvahChargeThemeExtension.colorSchemeExtended
 
 /**
  * Default graph colors following Jetpack Compose patterns.
@@ -13,10 +13,10 @@ internal object GraphColorDefaults {
 
     @Composable
     fun colors(
-        offerSelectedLine: Color = MaterialTheme.colorScheme.brand,
-        offerSelectedArea: Color = MaterialTheme.colorScheme.brand.copy(alpha = 0.6f),
-        offerUnselectedLine: Color = MaterialTheme.colorScheme.brand.copy(alpha = 0.6f),
-        offerUnselectedArea: Color = MaterialTheme.colorScheme.brand.copy(alpha = 0.3f),
+        offerSelectedLine: Color = MaterialTheme.colorSchemeExtended.brand,
+        offerSelectedArea: Color = MaterialTheme.colorSchemeExtended.brand.copy(alpha = 0.6f),
+        offerUnselectedLine: Color = MaterialTheme.colorSchemeExtended.brand.copy(alpha = 0.6f),
+        offerUnselectedArea: Color = MaterialTheme.colorSchemeExtended.brand.copy(alpha = 0.3f),
         regularSelectedLine: Color = Color.Companion.Gray.copy(alpha = 0.8f),
         regularSelectedArea: Color = Color.Companion.Gray.copy(alpha = 0.6f),
         regularUnselectedLine: Color = Color.Companion.Gray.copy(alpha = 0.4f),

--- a/charge/src/main/java/de/elvah/charge/platform/ui/theme/Theme.kt
+++ b/charge/src/main/java/de/elvah/charge/platform/ui/theme/Theme.kt
@@ -1,34 +1,15 @@
 package de.elvah.charge.platform.ui.theme
 
-import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.dynamicDarkColorScheme
-import androidx.compose.material3.dynamicLightColorScheme
-import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
-
-private val DarkColorScheme = darkColorScheme(
-    primary = primaryDark,
-    secondary = secondaryDark,
-    background = containerDark,
-    surface = canvasDark,
-    tertiary = canvasDark,
-    onTertiary = containerDark
-)
-
-private val LightColorScheme = lightColorScheme(
-    primary = primary,
-    secondary = secondary,
-    background = container,
-    surface = canvas,
-    tertiary = container,
-    onTertiary = canvas
-)
+import de.elvah.charge.platform.ui.theme.colors.ElvahChargeColors
+import de.elvah.charge.platform.ui.theme.colors.LocalColorSchemeExtended
+import de.elvah.charge.platform.ui.theme.colors.brandColor
+import de.elvah.charge.platform.ui.theme.colors.onBrandColor
 
 @Composable
 internal fun ElvahChargeTheme(
@@ -36,21 +17,15 @@ internal fun ElvahChargeTheme(
     dynamicColor: Boolean = false,
     content: @Composable () -> Unit
 ) {
-    val colorScheme = when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-            val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
-        }
-
-        darkTheme -> DarkColorScheme
-        else -> LightColorScheme
+    CompositionLocalProvider(
+        LocalColorSchemeExtended provides ElvahChargeColors.getColorSchemeExtended(darkTheme),
+    ) {
+        MaterialTheme(
+            colorScheme = ElvahChargeColors.getColorScheme(darkTheme, dynamicColor),
+            typography = Typography,
+            content = content
+        )
     }
-
-    MaterialTheme(
-        colorScheme = colorScheme,
-        typography = Typography,
-        content = content
-    )
 }
 
 internal val ColorScheme.brand: Color

--- a/charge/src/main/java/de/elvah/charge/platform/ui/theme/Theme.kt
+++ b/charge/src/main/java/de/elvah/charge/platform/ui/theme/Theme.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.graphics.Color
 import de.elvah.charge.platform.ui.theme.colors.ElvahChargeColors
 import de.elvah.charge.platform.ui.theme.colors.LocalColorSchemeExtended
-import de.elvah.charge.platform.ui.theme.colors.brandColor
 import de.elvah.charge.platform.ui.theme.colors.onBrandColor
 
 @Composable
@@ -27,10 +26,6 @@ internal fun ElvahChargeTheme(
         )
     }
 }
-
-internal val ColorScheme.brand: Color
-    get() = brandColor
-
 
 internal val ColorScheme.onBrand: Color
     get() = onBrandColor

--- a/charge/src/main/java/de/elvah/charge/platform/ui/theme/Typography.kt
+++ b/charge/src/main/java/de/elvah/charge/platform/ui/theme/Typography.kt
@@ -3,7 +3,8 @@ package de.elvah.charge.platform.ui.theme
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
-
+import de.elvah.charge.platform.ui.theme.colors.primary
+import de.elvah.charge.platform.ui.theme.colors.secondary
 
 internal val titleXLarge = TextStyle(
     fontWeight = FontWeight.W400,

--- a/charge/src/main/java/de/elvah/charge/platform/ui/theme/colors/ColorSchemeExtended.kt
+++ b/charge/src/main/java/de/elvah/charge/platform/ui/theme/colors/ColorSchemeExtended.kt
@@ -1,0 +1,12 @@
+package de.elvah.charge.platform.ui.theme.colors
+
+import androidx.compose.ui.graphics.Color
+
+internal data class ColorSchemeExtended(
+    val primary: Color,
+    val decorativeStroke: Color,
+    val brand: Color,
+    val onBrand: Color,
+    val success: Color,
+    val onSuccess: Color,
+)

--- a/charge/src/main/java/de/elvah/charge/platform/ui/theme/colors/Colors.kt
+++ b/charge/src/main/java/de/elvah/charge/platform/ui/theme/colors/Colors.kt
@@ -1,4 +1,4 @@
-package de.elvah.charge.platform.ui.theme
+package de.elvah.charge.platform.ui.theme.colors
 
 import androidx.compose.ui.graphics.Color
 
@@ -9,18 +9,14 @@ internal val decorativeStroke = Color(0x2986868B)
 internal val success = Color(0xFFC7F8C0)
 internal val onSuccess = Color(0xFF123F00)
 
-
 // Light Colors
 internal val primary = Color(0xFF000000)
 internal val secondary = Color(0xFF474747)
 internal val container = Color(0xFFFFFFFF)
 internal val canvas = Color(0xFFF5F5F6)
 
-
 // Dark Colors
 internal val primaryDark = Color(0xFFFFFFFF)
 internal val secondaryDark = Color(0xFF9A9A9A)
 internal val containerDark = Color(0xFF1C1C1E)
 internal val canvasDark = Color(0xFF2C2C2E)
-
-

--- a/charge/src/main/java/de/elvah/charge/platform/ui/theme/colors/ElvahChargeColors.kt
+++ b/charge/src/main/java/de/elvah/charge/platform/ui/theme/colors/ElvahChargeColors.kt
@@ -1,0 +1,69 @@
+package de.elvah.charge.platform.ui.theme.colors
+
+import android.os.Build
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+
+internal object ElvahChargeColors {
+
+    private val LightColorScheme = lightColorScheme(
+        primary = primary,
+        secondary = secondary,
+        background = container,
+        surface = canvas,
+        tertiary = container,
+        onTertiary = canvas,
+    )
+
+    private val LightColorSchemeExtended = ColorSchemeExtended(
+        primary = primary,
+        decorativeStroke = decorativeStroke,
+        brand = brandColor,
+        onBrand = onBrandColor,
+        success = success,
+        onSuccess = onSuccess,
+    )
+
+    private val DarkColorScheme = darkColorScheme(
+        primary = primaryDark,
+        secondary = secondaryDark,
+        background = containerDark,
+        surface = canvasDark,
+        tertiary = canvasDark,
+        onTertiary = containerDark,
+    )
+
+    private val DarkColorSchemeExtended = ColorSchemeExtended(
+        primary = primary,
+        decorativeStroke = decorativeStroke,
+        brand = brandColor,
+        onBrand = onBrandColor,
+        success = success,
+        onSuccess = onSuccess,
+    )
+
+    @Composable
+    fun getColorScheme(darkTheme: Boolean, dynamicColor: Boolean): ColorScheme {
+        return when {
+            dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+                val context = LocalContext.current
+                if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+            }
+
+            darkTheme -> DarkColorScheme
+            else -> LightColorScheme
+        }
+    }
+
+    fun getColorSchemeExtended(darkTheme: Boolean): ColorSchemeExtended {
+        return when {
+            darkTheme -> DarkColorSchemeExtended
+            else -> LightColorSchemeExtended
+        }
+    }
+}

--- a/charge/src/main/java/de/elvah/charge/platform/ui/theme/colors/ElvahChargeColors.kt
+++ b/charge/src/main/java/de/elvah/charge/platform/ui/theme/colors/ElvahChargeColors.kt
@@ -20,7 +20,7 @@ internal object ElvahChargeColors {
         onTertiary = canvas,
     )
 
-    private val LightColorSchemeExtended = ColorSchemeExtended(
+    internal val LightColorSchemeExtended = ColorSchemeExtended(
         primary = primary,
         decorativeStroke = decorativeStroke,
         brand = brandColor,

--- a/charge/src/main/java/de/elvah/charge/platform/ui/theme/colors/ElvahChargeThemeExtension.kt
+++ b/charge/src/main/java/de/elvah/charge/platform/ui/theme/colors/ElvahChargeThemeExtension.kt
@@ -1,0 +1,13 @@
+package de.elvah.charge.platform.ui.theme.colors
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+
+// add colors as extension of our material theme
+internal object ElvahChargeThemeExtension {
+
+    @Suppress("UnusedReceiverParameter")
+    internal val MaterialTheme.colorSchemeExtended: ColorSchemeExtended
+        @Composable
+        get() = LocalColorSchemeExtended.current
+}

--- a/charge/src/main/java/de/elvah/charge/platform/ui/theme/colors/LocalColorSchemeExtended.kt
+++ b/charge/src/main/java/de/elvah/charge/platform/ui/theme/colors/LocalColorSchemeExtended.kt
@@ -1,15 +1,7 @@
 package de.elvah.charge.platform.ui.theme.colors
 
 import androidx.compose.runtime.staticCompositionLocalOf
-import androidx.compose.ui.graphics.Color
 
 internal val LocalColorSchemeExtended = staticCompositionLocalOf {
-    ColorSchemeExtended(
-        primary = Color.Unspecified,
-        decorativeStroke = Color.Unspecified,
-        brand = Color.Unspecified,
-        onBrand = Color.Unspecified,
-        success = Color.Unspecified,
-        onSuccess = Color.Unspecified,
-    )
+    ElvahChargeColors.LightColorSchemeExtended
 }

--- a/charge/src/main/java/de/elvah/charge/platform/ui/theme/colors/LocalColorSchemeExtended.kt
+++ b/charge/src/main/java/de/elvah/charge/platform/ui/theme/colors/LocalColorSchemeExtended.kt
@@ -1,0 +1,15 @@
+package de.elvah.charge.platform.ui.theme.colors
+
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+
+internal val LocalColorSchemeExtended = staticCompositionLocalOf {
+    ColorSchemeExtended(
+        primary = Color.Unspecified,
+        decorativeStroke = Color.Unspecified,
+        brand = Color.Unspecified,
+        onBrand = Color.Unspecified,
+        success = Color.Unspecified,
+        onSuccess = Color.Unspecified,
+    )
+}


### PR DESCRIPTION
### Checklist
- [x] Do not use the colors directly in composables components.
- [x] Add `colorSchemeExtended` for new color definitions.